### PR TITLE
Fix legacy transactions

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -683,6 +683,7 @@ type storedReceiptRLP struct {
 	L1GasPrice *big.Int `rlp:"optional"` // OVM legacy
 	L1Fee      *big.Int `rlp:"optional"` // OVM legacy
 	FeeScalar  string   `rlp:"optional"` // OVM legacy
+	L2BobaFee  *big.Int `rlp:"optional"` // OVM legacy
 }
 
 // ReceiptLogs is a barebone version of ReceiptForStorage which only keeps

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -811,6 +811,36 @@ func TestParseLegacyReceiptRLP(t *testing.T) {
 		L1GasPrice: gasUsed,
 		L1Fee:      gasUsed,
 		FeeScalar:  "6",
+	}
+
+	data, err := rlp.EncodeToBytes(receipt)
+	require.NoError(t, err)
+	var result storedReceiptRLP
+	err = rlp.DecodeBytes(data, &result)
+	require.NoError(t, err)
+	require.Equal(t, receipt.L1GasUsed, result.L1GasUsed)
+	require.Equal(t, receipt.L1GasPrice, result.L1GasPrice)
+	require.Equal(t, receipt.L1Fee, result.L1Fee)
+	require.Equal(t, receipt.FeeScalar, result.FeeScalar)
+}
+
+func TestParseLegacyReceiptRLPWithBoba(t *testing.T) {
+	// Create a gasUsed value greater than a uint64 can represent
+	gasUsed := big.NewInt(0)
+	gasUsed = gasUsed.SetUint64(math.MaxUint64)
+	gasUsed = gasUsed.Add(gasUsed, big.NewInt(math.MaxInt64))
+	sanityCheck := (&big.Int{}).SetUint64(gasUsed.Uint64())
+	require.NotEqual(t, gasUsed, sanityCheck)
+	receipt := types.LegacyOptimismStoredReceiptRLP{
+		CumulativeGasUsed: 1,
+		Logs: []*types.LogForStorage{
+			{Address: common.BytesToAddress([]byte{0x11})},
+			{Address: common.BytesToAddress([]byte{0x01, 0x11})},
+		},
+		L1GasUsed:  gasUsed,
+		L1GasPrice: gasUsed,
+		L1Fee:      gasUsed,
+		FeeScalar:  "6",
 		L2BobaFee:  gasUsed,
 	}
 
@@ -823,6 +853,7 @@ func TestParseLegacyReceiptRLP(t *testing.T) {
 	require.Equal(t, receipt.L1GasPrice, result.L1GasPrice)
 	require.Equal(t, receipt.L1Fee, result.L1Fee)
 	require.Equal(t, receipt.FeeScalar, result.FeeScalar)
+	require.Equal(t, receipt.L2BobaFee, result.L2BobaFee)
 }
 
 func TestDeriveLogFields(t *testing.T) {

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -811,6 +811,7 @@ func TestParseLegacyReceiptRLP(t *testing.T) {
 		L1GasPrice: gasUsed,
 		L1Fee:      gasUsed,
 		FeeScalar:  "6",
+		L2BobaFee:  gasUsed,
 	}
 
 	data, err := rlp.EncodeToBytes(receipt)

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -166,6 +166,7 @@ type LegacyOptimismStoredReceiptRLP struct {
 	L1GasPrice        *big.Int
 	L1Fee             *big.Int
 	FeeScalar         string
+	L2BobaFee         *big.Int `rlp:"optional"`
 }
 
 // LogForStorage is a wrapper around a Log that handles


### PR DESCRIPTION
In our legacy transaction receipt, we have a custom field called L2BobaFee. This fixes the issue of fetching the transaction receipts for legacy blocks.